### PR TITLE
Add RISC-V syscall and AssemblyScript support

### DIFF
--- a/src/aot_generator.rs
+++ b/src/aot_generator.rs
@@ -692,7 +692,7 @@ pub fn generate(middle: &mut context::Middle) -> Result<(), Box<dyn std::error::
                         init_function_list.push(format!("init_memory{}", i));
                     }
                     // On CKB
-                    context::Platform::CKBVMSpectest => {
+                    context::Platform::CKBVMSpectest | context::Platform::CKBVMAssemblyScript => {
                         let memory_size = memory_type.limits.initial as usize * 65536;
                         let mut memory_data: Vec<u8> = vec![0x00; memory_size];
                         for (_, e) in data.iter().enumerate() {

--- a/src/aot_generator.rs
+++ b/src/aot_generator.rs
@@ -944,8 +944,13 @@ pub fn generate(middle: &mut context::Middle) -> Result<(), Box<dyn std::error::
         glue_file.write("int main(int argc, char *argv[]) {");
         glue_file.write("g_argc = argc;");
         glue_file.write("g_argv = argv;");
+        match middle.config.platform {
+            context::Platform::PosixX8664Wasi => {
+                glue_file.write("init_wasi();");
+            }
+            _ => {}
+        }
         glue_file.write("init();");
-        glue_file.write("init_wasi();");
         glue_file.write("wavm_exported_function__start(NULL);");
         glue_file.write("return 0;");
         glue_file.write("}");

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -19,7 +19,7 @@ pub fn compile<P: AsRef<std::path::Path>>(
     let mut cmd_wavm = std::process::Command::new(&middle.config.binary_wavm);
     cmd_wavm.arg("compile").arg("--enable").arg("all");
     match middle.config.platform {
-        context::Platform::CKBVMSpectest => {
+        context::Platform::CKBVMAssemblyScript | context::Platform::CKBVMSpectest => {
             cmd_wavm.arg("--target-triple").arg("riscv64");
         }
         _ => {}

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -125,7 +125,7 @@ pub fn compile<P: AsRef<std::path::Path>>(
 
     let mut main_file = code_builder::CodeBuilder::create(&middle.path_c);
     let platform_header = match middle.config.platform {
-        context::Platform::CKBVMAssemblyScript => "platfrom/ckb_vm_assemblyscript.h",
+        context::Platform::CKBVMAssemblyScript => "platform/ckb_vm_assemblyscript.h",
         context::Platform::CKBVMSpectest => "platform/ckb_vm_spectest.h",
         context::Platform::PosixX8664 => "platform/posix_x86_64.h",
         context::Platform::PosixX8664Spectest => "platform/posix_x86_64_spectest.h",

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,7 +14,7 @@ pub struct Config {
     // Path of cc, usually the result of "$ which gcc".
     pub binary_cc: String,
     pub binary_wavm: String,
-    // Platfrom flag and their files.
+    // Platform flag and their files.
     pub platform: Platform,
     pub platform_ckb_vm_assemblyscript_h: &'static str,
     pub platform_ckb_vm_assemblyscript_lds: &'static str,

--- a/src/gcc.rs
+++ b/src/gcc.rs
@@ -9,6 +9,11 @@ pub fn build(middle: &context::Middle) -> Result<(), Box<dyn std::error::Error>>
         .arg(middle.path_object.to_str().unwrap())
         .arg(middle.path_c.to_str().unwrap());
     match middle.config.platform {
+        context::Platform::CKBVMAssemblyScript => {
+            cmd.arg(middle.path_prog.join("platform/ckb_vm_assemblyscript_runtime.S"));
+            cmd.arg("-Wl,-T");
+            cmd.arg(middle.path_prog.join("platform/ckb_vm_assemblyscript.lds"));
+        }
         context::Platform::CKBVMSpectest => {
             cmd.arg(middle.path_prog.join("platform/ckb_vm_spectest_runtime.S"));
             cmd.arg("-Wl,-T");

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .to_str()
             .unwrap(),
     );
+    let mut fl_gcc = String::from("");
     let mut fl_verbose = false;
     let mut fl_save = false;
     {
@@ -41,6 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
         ap.refer(&mut fl_wavm)
             .add_option(&["--wavm"], argparse::Store, "WAVM binary");
+        ap.refer(&mut fl_gcc).add_option(&["--gcc"], argparse::Store, "GCC");
         ap.refer(&mut fl_verbose)
             .add_option(&["-v", "--verbose"], argparse::StoreTrue, "");
         ap.refer(&mut fl_save)
@@ -50,6 +52,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if fl_source.is_empty() {
         rog::println!("wasc: missing file operand");
         std::process::exit(1);
+    }
+    if fl_gcc.is_empty() {
+        match fl_platform.as_str() {
+            "ckb_vm_assemblyscript" | "ckb_vm_spectest" => {
+                fl_gcc = String::from("riscv64-unknown-elf-gcc");
+            }
+            "posix_x86_64" | "posix_x86_64_spectest" | "posix_x86_64_wasi" => {
+                fl_gcc = String::from("gcc");
+            }
+            _ => {}
+        }
     }
     if fl_verbose {
         rog::reg("wasc");
@@ -78,6 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
     config.binary_wavm = fl_wavm;
+    config.binary_cc = fl_gcc;
 
     let middle = compile::compile(&fl_source, config)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     source [WASM/WA(S)T source file]
     //
     // PLATFORM:
+    //   ckb_vm_assemblyscript
+    //   ckb_vm_spectest
     //   posix_x86_64
     //   posix_x86_64_spectest
     //   posix_x86_64_wasi
@@ -58,6 +60,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut config = context::Config::default();
     config.platform = match fl_platform.as_str() {
+        "ckb_vm_assemblyscript" => context::Platform::CKBVMAssemblyScript,
+        "ckb_vm_spectest" => context::Platform::CKBVMSpectest,
         "posix_x86_64" => context::Platform::PosixX8664,
         "posix_x86_64_spectest" => context::Platform::PosixX8664Spectest,
         "posix_x86_64_wasi" => context::Platform::PosixX8664Wasi,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Usage of wasc:
     //
     // wasc
+    //     --gcc [GCC binary]
     //     -p --platform [PLATFORM]
-    //     --wasm [WAVM binary]
+    //     -s --save
     //     -v --verbose
+    //     --wasm [WAVM binary]
     //     source [WASM/WA(S)T source file]
     //
     // PLATFORM:
@@ -53,17 +55,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         rog::println!("wasc: missing file operand");
         std::process::exit(1);
     }
-    if fl_gcc.is_empty() {
-        match fl_platform.as_str() {
-            "ckb_vm_assemblyscript" | "ckb_vm_spectest" => {
-                fl_gcc = String::from("riscv64-unknown-elf-gcc");
-            }
-            "posix_x86_64" | "posix_x86_64_spectest" | "posix_x86_64_wasi" => {
-                fl_gcc = String::from("gcc");
-            }
-            _ => {}
-        }
-    }
     if fl_verbose {
         rog::reg("wasc");
         rog::reg("wasc::aot_generator");
@@ -90,6 +81,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::process::exit(1);
         }
     };
+    if fl_gcc.is_empty() {
+        match config.platform {
+            context::Platform::CKBVMAssemblyScript | context::Platform::CKBVMSpectest => {
+                fl_gcc = String::from("riscv64-unknown-elf-gcc");
+            }
+            context::Platform::PosixX8664
+            | context::Platform::PosixX8664Spectest
+            | context::Platform::PosixX8664Wasi => {
+                fl_gcc = String::from("gcc");
+            }
+            _ => {}
+        }
+    }
     config.binary_wavm = fl_wavm;
     config.binary_cc = fl_gcc;
 

--- a/src/platform/ckb_vm_assemblyscript.h
+++ b/src/platform/ckb_vm_assemblyscript.h
@@ -55,15 +55,39 @@ void invalidFloatOperationTrap()
     exit(1);
 }
 
-uint64_t __atomic_load_8(void* p, int32_t _mode)
+uint64_t __atomic_load_8(void *p, int32_t _mode)
 {
-  (void) _mode;
-  return *((uint64_t*) ((uintptr_t) p));
+    (void)_mode;
+    return *((uint64_t *)((uintptr_t)p));
 }
 
-void* wavm_env_abort(void *dummy, int32_t a, int32_t b, int32_t c, int32_t d)
+void *wavm_env_abort(void *dummy, int32_t a, int32_t b, int32_t c, int32_t d)
 {
     exit(1);
+}
+
+static inline long __internal_syscall(long n, long _a0, long _a1, long _a2,
+                                      long _a3, long _a4, long _a5)
+{
+    register long a0 asm("a0") = _a0;
+    register long a1 asm("a1") = _a1;
+    register long a2 asm("a2") = _a2;
+    register long a3 asm("a3") = _a3;
+    register long a4 asm("a4") = _a4;
+    register long a5 asm("a5") = _a5;
+    register long syscall_id asm("a7") = n;
+    asm volatile("scall"
+                 : "+r"(a0)
+                 : "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a5), "r"(syscall_id));
+    return a0;
+}
+
+wavm_ret_int64_t wavm_env_syscall(void *dummy, int64_t n, int64_t _a0, int64_t _a1, int64_t _a2, int64_t _a3, int64_t _a4, int64_t _a5)
+{
+    wavm_ret_int64_t ret;
+    ret.dummy = dummy;
+    ret.value = __internal_syscall(n, _a0, _a1, _a2, _a3, _a4, _a5);
+    return ret;
 }
 
 #endif /* WAVM_CKB_VM_ASSEMBLYSCRIPT_H */

--- a/src/platform/ckb_vm_assemblyscript.h
+++ b/src/platform/ckb_vm_assemblyscript.h
@@ -55,10 +55,10 @@ void invalidFloatOperationTrap()
     exit(1);
 }
 
-uint64_t __atomic_load_8(void *p, int32_t _mode)
+uint64_t __atomic_load_8(void* p, int32_t _mode)
 {
-    (void)_mode;
-    return *((uint64_t *)((uintptr_t)p));
+  (void) _mode;
+  return *((uint64_t*) ((uintptr_t) p));
 }
 
 void* wavm_env_abort(void *dummy, int32_t a, int32_t b, int32_t c, int32_t d)

--- a/src/platform/ckb_vm_assemblyscript.h
+++ b/src/platform/ckb_vm_assemblyscript.h
@@ -82,11 +82,15 @@ static inline long __internal_syscall(long n, long _a0, long _a1, long _a2,
     return a0;
 }
 
+#define syscall(n, a, b, c, d, e, f)                                             \
+    __internal_syscall(n, (long)(a), (long)(b), (long)(c), (long)(d), (long)(e), \
+                       (long)(f))
+
 wavm_ret_int64_t wavm_env_syscall(void *dummy, int64_t n, int64_t _a0, int64_t _a1, int64_t _a2, int64_t _a3, int64_t _a4, int64_t _a5)
 {
     wavm_ret_int64_t ret;
     ret.dummy = dummy;
-    ret.value = __internal_syscall(n, _a0, _a1, _a2, _a3, _a4, _a5);
+    ret.value = syscall(n, _a0, _a1, _a2, _a3, _a4, _a5);
     return ret;
 }
 

--- a/src/platform/ckb_vm_assemblyscript.h
+++ b/src/platform/ckb_vm_assemblyscript.h
@@ -86,12 +86,38 @@ static inline long __internal_syscall(long n, long _a0, long _a1, long _a2,
     __internal_syscall(n, (long)(a), (long)(b), (long)(c), (long)(d), (long)(e), \
                        (long)(f))
 
-wavm_ret_int64_t wavm_env_syscall(void *dummy, int64_t n, int64_t _a0, int64_t _a1, int64_t _a2, int64_t _a3, int64_t _a4, int64_t _a5)
+#ifdef MEMORY0_DEFINED
+wavm_ret_int64_t wavm_env_syscall(void *dummy, int64_t n, int64_t _a0, int64_t _a1, int64_t _a2, int64_t _a3, int64_t _a4, int64_t _a5, int64_t mode)
 {
     wavm_ret_int64_t ret;
     ret.dummy = dummy;
+    if (mode & 0b100000)
+    {
+        _a0 = (int64_t)&memoryOffset0.base[0] + _a0;
+    }
+    if (mode & 0b010000)
+    {
+        _a1 = (int64_t)&memoryOffset0.base[0] + _a1;
+    }
+    if (mode & 0b001000)
+    {
+        _a2 = (int64_t)&memoryOffset0.base[0] + _a2;
+    }
+    if (mode & 0b000100)
+    {
+        _a3 = (int64_t)&memoryOffset0.base[0] + _a3;
+    }
+    if (mode & 0b000010)
+    {
+        _a4 = (int64_t)&memoryOffset0.base[0] + _a4;
+    }
+    if (mode & 0b000001)
+    {
+        _a5 = (int64_t)&memoryOffset0.base[0] + _a5;
+    }
     ret.value = syscall(n, _a0, _a1, _a2, _a3, _a4, _a5);
     return ret;
 }
+#endif /* MEMORY0_DEFINED */
 
 #endif /* WAVM_CKB_VM_ASSEMBLYSCRIPT_H */

--- a/src/platform/ckb_vm_assemblyscript.h
+++ b/src/platform/ckb_vm_assemblyscript.h
@@ -61,7 +61,7 @@ uint64_t __atomic_load_8(void *p, int32_t _mode)
     return *((uint64_t *)((uintptr_t)p));
 }
 
-void wavm_env_abort(void *dummy, int32_t a, int32_t b, int32_t c, int32_t d)
+void* wavm_env_abort(void *dummy, int32_t a, int32_t b, int32_t c, int32_t d)
 {
     exit(1);
 }

--- a/src/platform/ckb_vm_spectest.h
+++ b/src/platform/ckb_vm_spectest.h
@@ -19,8 +19,9 @@ extern uint8_t memory0[];
 extern uint32_t memory0_length;
 int32_t wavm_intrinsic_memory_grow(void *dummy, int32_t grow_by)
 {
-  if ((memoryOffset0.num_pages + grow_by) >  MEMORY0_MAX_PAGE) {
-      return -1;
+  if ((memoryOffset0.num_pages + grow_by) > MEMORY0_MAX_PAGE)
+  {
+    return -1;
   }
   int32_t old_pages = memoryOffset0.num_pages;
   memory0_length += grow_by * WAVM_PAGE_SIZE;
@@ -54,10 +55,10 @@ void invalidFloatOperationTrap()
   exit(1);
 }
 
-uint64_t __atomic_load_8(void* p, int32_t _mode)
+uint64_t __atomic_load_8(void *p, int32_t _mode)
 {
-  (void) _mode;
-  return *((uint64_t*) ((uintptr_t) p));
+  (void)_mode;
+  return *((uint64_t *)((uintptr_t)p));
 }
 
 int32_t wavm_spectest_global_i32 = 42;


### PR DESCRIPTION
In short, this PR implements two things:

- AssemblyScript is supported, as a new platform for wasc
- Syscall is confirmed to be achievable

An example:

```ts
export declare function syscall(n: i64, a: i64, b: i64, c: i64, d: i64, e: i64, f: i64, mode: i64): i64;

export function _start(): i32 {
  const str = "Hello World!";
  let strEncoded = String.UTF8.encode(str, true);
  syscall(2192, changetype<usize>(strEncoded), strEncoded.byteLength - 1, 0, 0, 0, 0, 0b100000);
  return 0;
}
```